### PR TITLE
Pylint configuration

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -21,4 +21,6 @@ jobs:
         pip install -r requirements.txt
     - name: Analysing the code with pylint
       run: |
-        pylint $(git ls-files '*.py')
+        pwd
+        ls
+        pylint $(git ls-files '*.py') --rcfile=.pylintrc

--- a/.pylintrc
+++ b/.pylintrc
@@ -46,7 +46,7 @@ fail-under=10
 #from-stdin=
 
 # Files or directories to be skipped. They should be base names, not paths.
-ignore=CVS,generated_ui
+ignore=splash.py
 
 # Add files or directories matching the regular expressions patterns to the
 # ignore-list. The regex matches against paths and can be in Posix or Windows
@@ -63,7 +63,7 @@ ignore-patterns=^\.#
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis). It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=cv2
+ignored-modules=cv2,splash
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().


### PR DESCRIPTION
Enable pylintrc file and ignore generated python file findings.

I couldnt get the pylint pattern matching to ignore all .py files in generated_ui/... Not sure why. This solution works, but is annoying to manually update with newly generated ui->.py files.